### PR TITLE
Understanding Windows encoding issues

### DIFF
--- a/reveal/cli.py
+++ b/reveal/cli.py
@@ -285,8 +285,14 @@ def analyze_directory_level_2(dir_path: Path, grep_pattern: Optional[str] = None
                 line_count = "?"
                 try:
                     if size < 1024 * 1024:  # Only for files < 1MB
-                        with open(file_path, 'r', encoding='utf-8') as f:
-                            line_count = str(sum(1 for _ in f))
+                        # Try multiple encodings for Windows compatibility
+                        for encoding in ['utf-8-sig', 'utf-8', 'cp1252', 'iso-8859-1']:
+                            try:
+                                with open(file_path, 'r', encoding=encoding) as f:
+                                    line_count = str(sum(1 for _ in f))
+                                break
+                            except UnicodeDecodeError:
+                                continue
                 except:
                     pass
 

--- a/reveal/plugin_loader.py
+++ b/reveal/plugin_loader.py
@@ -111,7 +111,7 @@ class PluginLoader:
 
     def load_plugin(self, yaml_path: Path):
         """Load a single plugin from YAML file"""
-        with open(yaml_path, "r") as f:
+        with open(yaml_path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         plugin = PluginDefinition.from_yaml(data)


### PR DESCRIPTION
Fixes file reading issues on Windows by trying multiple encodings:
- UTF-8 with BOM (utf-8-sig) - handles Notepad files
- CP1252 - Windows Western European default
- ISO-8859-1 - Latin-1 fallback
- UTF-16 - Windows applications (PowerShell, SQL Server)

Changes:
- core.py: Enhanced read_file_safe() with encoding detection
- cli.py: Fixed directory analysis to try multiple encodings
- plugin_loader.py: Explicit UTF-8 encoding for YAML files

This prevents files created by Windows tools (Notepad, Excel, SQL Server) from being incorrectly marked as binary files.