### PR TITLE
Fix Windows console encoding for emoji/unicode support

### DIFF
--- a/reveal/main.py
+++ b/reveal/main.py
@@ -1,6 +1,7 @@
 """Clean, simple CLI for reveal."""
 
 import sys
+import os
 import argparse
 from pathlib import Path
 from typing import Optional
@@ -9,6 +10,21 @@ from .tree_view import show_directory_tree
 
 
 def main():
+    """Main CLI entry point."""
+    # Fix Windows console encoding for emoji/unicode support
+    if sys.platform == 'win32':
+        # Set environment variable for subprocess compatibility
+        os.environ.setdefault('PYTHONIOENCODING', 'utf-8')
+        # Reconfigure stdout/stderr to use UTF-8 with error handling
+        if hasattr(sys.stdout, 'reconfigure'):
+            sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+        if hasattr(sys.stderr, 'reconfigure'):
+            sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+
+    _main_impl()
+
+
+def _main_impl():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
         description='Reveal: Explore code semantically',


### PR DESCRIPTION
## Problem
On Windows, `reveal` crashes with `UnicodeEncodeError` when displaying emoji characters (📁, 📄, etc.) because the default Windows console encoding (cp1252) cannot handle them.

**Error example:**
```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f4c1' in position 0: 
character maps to <undefined>
```

## Solution
This PR adds Windows-specific UTF-8 encoding configuration to `reveal/main.py`:
- Sets `PYTHONIOENCODING` environment variable to `'utf-8'`
- Reconfigures `stdout` and `stderr` to use UTF-8 encoding with `'replace'` error handling
- Only applied when running on Windows (`sys.platform == 'win32'`)

## Changes
- Modified `reveal/main.py`:
  - Added `import os`
  - Split `main()` into wrapper that configures encoding + `_main_impl()`
  - Windows encoding fix is non-invasive and only runs on Windows

## Testing
Tested on Windows 11 with MSYS2 bash:
- ✅ Directory trees display emoji correctly
- ✅ File structure output works without crashes
- ✅ No impact on Linux/macOS (encoding config only runs on Windows)

**Before:**
```
UnicodeEncodeError when running reveal on any path
```

**After:**
```
📁 ./
├── file.py (100 lines, Python)
└── README.md (50 lines, Markdown)
```

## Platform Compatibility
- ✅ Windows: Fixed
- ✅ Linux: No change (not executed)
- ✅ macOS: No change (not executed)

This fix makes `reveal` fully functional on Windows while maintaining compatibility with other platforms.